### PR TITLE
Edited the deployment template to set postgis.host to None

### DIFF
--- a/deployment-templates/models/000_config.py
+++ b/deployment-templates/models/000_config.py
@@ -29,7 +29,7 @@ deployment_settings.mongodb.password = 'mongo'
 
 # PostGIS Settings
 deployment_settings.postgis = blank ()
-deployment_settings.postgis.host = "localhost"
+deployment_settings.postgis.host = None
 deployment_settings.postgis.port = 5432
 deployment_settings.postgis.database = "geodata"
 deployment_settings.postgis.username = "postgis"


### PR DESCRIPTION
This removes the error if the user does not have psycopg2, when developing off sqlite.
